### PR TITLE
Add research outputs and reformat site sections

### DIFF
--- a/conference.html
+++ b/conference.html
@@ -3,39 +3,29 @@
 body { font-family: Georgia, serif; background: #fafafa; color: #222; max-width: 950px; margin: auto; padding: 2rem; line-height: 1.6; }
 nav { background: #f5f5f5; padding: 1em; text-align: center; position: sticky; top: 0; }
 nav a { margin: 0 15px; text-decoration: none; color: #0366d6; font-weight: bold; }
-h1,h2 { font-family: 'Helvetica Neue', Arial, sans-serif; color: #003366; }
+h1 { font-family: 'Helvetica Neue', Arial, sans-serif; color: #003366; }
 .card { background: #fff; padding: 1.2em; margin: 1em 0; border-radius: 8px; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
-.group { border: 1px solid #e6e6e6; border-radius: 10px; padding: 10px 12px; }
 .small { color:#444; font-size: 0.95rem; }
-.badge { display:inline-block; background:#003366; color:#fff; border-radius:999px; padding:0.1rem 0.5rem; font-size:0.8rem; }
+table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
+th { background: #f0f4f8; }
 </style>
 </head><body>
 <h1>Conferences & Activities</h1>
 <nav><a href="index.html">Home</a><a href="research.html">Research</a><a href="milestones.html">Milestones</a><a href="conference.html">Conferences</a><a href="teaching.html">Teaching</a><a href="professional.html">Professional</a><a href="CvResumeChenhao05252025.pdf">CV</a></nav>
 
-<div class="card group">
-  <h2>2025</h2>
-  <ul>
-    <li>INFORMS Annual Meeting — Session Chair（Scheduled）</li>
-    <li>DSI Annual Conference — Presenter（Scheduled）</li>
-    <!-- POMS 2025 assigned but unable to serve → 不在此处展示 -->
-  </ul>
-</div>
-
-<div class="card group">
-  <h2>2024</h2>
-  <ul>
-    <li>DSI Annual Conference — Presenter（Completed）</li>
-    <li>INFORMS Annual Meeting — Presenter（Completed）</li>
-  </ul>
-</div>
-
-<div class="card group">
-  <h2>2023</h2>
-  <ul>
-    <li>INFORMS Annual Meeting — Presenter（Completed）</li>
-    <li>POMS Annual Meeting (CHOM) — Invited Presenter（Completed）</li>
-  </ul>
+<div class="card">
+  <table>
+    <thead><tr><th>Year</th><th>Conference / Activity</th><th>Role</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td>2025</td><td>INFORMS Annual Meeting — Service Science Track</td><td>Session Chair</td><td>Scheduled</td></tr>
+      <tr><td>2025</td><td>DSI Annual Conference</td><td>Presenter</td><td>Scheduled</td></tr>
+      <tr><td>2024</td><td>DSI Annual Conference</td><td>Presenter</td><td>Completed</td></tr>
+      <tr><td>2024</td><td>INFORMS Annual Meeting</td><td>Presenter</td><td>Completed</td></tr>
+      <tr><td>2023</td><td>INFORMS Annual Meeting</td><td>Presenter</td><td>Completed</td></tr>
+      <tr><td>2023</td><td>POMS Annual Meeting (CHOM)</td><td>Invited Presenter</td><td>Completed</td></tr>
+    </tbody>
+  </table>
   <p class="small"><a href="CHOM.pdf" target="_blank">CHOM 2023 Program Flyer (PDF)</a></p>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -140,9 +140,18 @@
       <div class="card">
         <h2>Education</h2>
         <ul class="tight">
-          <li>Rutgers Business School — Ph.D. Candidate, Supply Chain Management (2021–present), GPA 4.0/4.0</li>
-          <li>NYU Tandon — M.S., Engineering/Industrial Management (2021)</li>
-          <li>Boston University Questrom — B.S., Business Administration (2019, Dean’s List)</li>
+          <li>
+            <strong>Rutgers Business School</strong> — Ph.D. Candidate, Supply Chain Management (2021–present)<br>
+            GPA: 4.0/4.0<br>
+            Dean’s Competition for Summer Ph.D. Research Assistants (2022–2024)
+          </li>
+          <li>
+            <strong>NYU Tandon School of Engineering</strong> — M.S., Engineering/Industrial Management (2021)
+          </li>
+          <li>
+            <strong>Boston University Questrom School of Business</strong> — B.S., Business Administration (2019)<br>
+            Dean’s List
+          </li>
         </ul>
       </div>
     </section>

--- a/research.html
+++ b/research.html
@@ -87,6 +87,43 @@ th { background: #f0f4f8; }
   <p><strong>Systems approach to addressing ED congestion: The impact of inpatient length of stay variability on emergency department crowding</strong> — Project proposal (Nov 14, 2024; Jong M. Lim). Concept framing completed; data cleaning pipeline under development.</p>
 </div>
 
+<div class="card">
+  <h2>Proceedings</h2>
+  <ul>
+    <li>
+      <strong>House price prediction using polynomial regression with Particle Swarm Optimization</strong><br>
+      <em>Journal of Physics: Conference Series</em>, 1802(3), 032034, 2021.
+    </li>
+    <li>
+      <strong>Quantitative investment strategy analysis based on machine learning for share dealing</strong><br>
+      <em>2020 7th International Conference on Information Science and Control Engineering</em>.
+    </li>
+  </ul>
+</div>
+
+<div class="card">
+  <h2>Book</h2>
+  <p>
+    <strong>Strategies for Enhancing the Effectiveness of Internal Audit and Risk Control</strong><br>
+    Edited by Jie Hui, Jie Liu, Chenhao Zhou, Wenxuan Zhou.<br>
+    China Times Economic Publishing House, Beijing, Feb 2025.<br>
+    ISBN: 978-7-5119-3474-1.
+  </p>
+</div>
+
+<div class="card">
+  <h2>Service &amp; Reviewing</h2>
+  <table>
+    <thead><tr><th>Year(s)</th><th>Role</th><th>Venue / Track</th><th>Notes</th></tr></thead>
+    <tbody>
+      <tr><td>2025</td><td>Session Chair</td><td>INFORMS — Service Science Track</td><td>Chair &amp; Presenter</td></tr>
+      <tr><td>2024</td><td>Reviewer</td><td>DSI Annual Conference — Healthcare Track</td><td>Program reviewer</td></tr>
+      <tr><td>2025</td><td>Reviewer</td><td>DSI Annual Conference — Project Management; Gig Economy &amp; Social Media Research Tracks</td><td>Program reviewer</td></tr>
+      <tr><td>2022–present</td><td>Member</td><td>INFORMS; POMS; DSI</td><td>Professional memberships</td></tr>
+    </tbody>
+  </table>
+</div>
+
 <div class="card small">Last updated 2025-09-12.</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Reformat home page education entries with consistent multi-line layout and awards
- Add proceedings, book, and service & reviewing sections to research page
- Present conferences in tabular form for clarity

## Testing
- `tidy -q -e index.html` *(warning: proprietary aria-current)*
- `tidy -q -e research.html`
- `tidy -q -e conference.html`


------
https://chatgpt.com/codex/tasks/task_e_68c47e8cc65c83258faf386f1bd8d6b4